### PR TITLE
Update bluetools/moneybrd-php-api dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": ">=2.1,<3.0",
-        "bluetools/moneybird-php-api": "2.3.2"
+        "bluetools/moneybird-php-api": "2.3.10"
     },
 
     "autoload": {


### PR DESCRIPTION
Current dependecy version of bluetools/moneybird-php-api is getting outdated, replacement of latest stable version will be 2.3.10. 

Haven't tested on PHP versions lower than 5.5, however no major changes have been applied since 2.3.2.
